### PR TITLE
Config to retain texture when switching clothing

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -85,6 +85,10 @@ local COMPONENTS = {
 
 PAUSE_DURATION_BETWEEN_UPDATES_IN_MS = 200
 
+-- Set this if you want to retain the texture IDs for the holstered and drawn versions of the weapon.
+-- This will stop the texture being changed whenever you pull out the weapon.
+RETAIN_TEXTURE_ID = true
+
 -- see https://docs.fivem.net/docs/game-references/ped-models/ for more ped models
 registerPed("mp_f_freemode_01")
 registerPed("mp_m_freemode_01")


### PR DESCRIPTION
A big flaw of the script is the inability to retain the texture of the clothing when switching. This is especially common in police EUP whereby ranks are displayed on the uniform. Without retaining the texture ID, the user's rank on the clothing will be reset each time. 

I have added a config option and updated the script to add support for retaining the texture ID, so the user does not have to specify a single texture to use each time.

This makes the script far, far more versatile for a large range of people.